### PR TITLE
Improvement: Layout and Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ Use "kubetop [command] --help" for more information about a command.
 
 The following keys can be used for the navigation in kubetop.
 
-| Key | Action |
-| --- | ------ |
-| `q`, `<C-c>` | Quit kubetop |
-| `k`, `<Up>`, `<MouseWheelUp>` | Scroll up (pods, nodes, logs) |
-| `j`, `<Down>`, `<MouseWheelDown>` | Scroll down (pods, nodes, logs) |
-| `<Tab>` | Select next container |
-| `p` | Pause updating data |
-| `<Enter>` | Select (pod, node, sortorder, filter) |
-| `<Escape>` | Cancle (pod details, sortorder, filter) |
-|  `<F1>` | Select sortorder |
-|  `<F2>` | Select namespace filter |
-|  `<F3>` | Select node filter |
-|  `<F4>` | Select status filter |
+| Key | Nodes | Pods | Pod Details |
+| --- | ----- | ---- | ----------- |
+| `q`, `<C-c>` | Quit | Quit | Quit |
+| `k`, `<Up>`, `<MouseWheelUp>` | Scroll up through nodes | Scroll up through pods | Scroll up through logs |
+| `j`, `<Down>`, `<MouseWheelDown>` | Scroll down through nodes | Scroll down through pods | Scroll down through logs |
+| `<Tab>` | - | - | Select next container |
+| `p` | Pause updating data | Pause updating data | Pause updating data |
+| `<Enter>` | Select node / Apply selected sortorder | Select pod / Apply selected sortorder/filter | - |
+| `<Escape>` | Close sortorder modal | Close sortorder/filter modal | Go back to the pods view |
+|  `<F1>` | Show available sortorder | Show available sortorder | - |
+|  `<F2>` | - | Show namespace filter | - |
+|  `<F3>` | - | Show node filter | - |
+|  `<F4>` | - | Show status filter | - |
 
 ## Dependencies
 

--- a/cmd/kubetop/kubetop.go
+++ b/cmd/kubetop/kubetop.go
@@ -20,8 +20,8 @@ var (
 
 var rootCmd = &cobra.Command{
 	Use:   "kubetop",
-	Short: "Display Resource (CPU/Memory/Storage) usage of pods",
-	Long:  "Display Resource (CPU/Memory/Storage) usage of pods",
+	Short: "Display Resource (CPU/Memory/Storage) usage of nodes and pods",
+	Long:  "Display Resource (CPU/Memory/Storage) usage of nodes and pods",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Initialize Kubernetes API client.
 		client, err := api.NewClient(kubeconfig)
@@ -82,8 +82,33 @@ var nodesCmd = &cobra.Command{
 	},
 }
 
+var podsCmd = &cobra.Command{
+	Use:   "pods",
+	Short: "Display Resource (CPU/Memory/Storage) usage of pods",
+	Long:  "Display Resource (CPU/Memory/Storage) usage of pods",
+	Run: func(cmd *cobra.Command, args []string) {
+		// Initialize Kubernetes API client.
+		client, err := api.NewClient(kubeconfig)
+		if err != nil {
+			log.Fatalf("Failed to initialize API client: %#v", err)
+		}
+
+		// Initialize and run the terminal user interface for kubetop.
+		t := term.Term{
+			APIClient: client,
+			ViewType:  widgets.ViewTypePods,
+		}
+
+		err = t.Run(api.Filter{Namespace: namespace, Node: "", Status: 10})
+		if err != nil {
+			log.Fatalf("Failed to initialize ui: %#v", err)
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(nodesCmd)
+	rootCmd.AddCommand(podsCmd)
 	rootCmd.AddCommand(versionCmd)
 
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests")

--- a/pkg/term/widgets/poddetails.go
+++ b/pkg/term/widgets/poddetails.go
@@ -3,6 +3,7 @@ package widgets
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/ricoberger/kubetop/pkg/api"
 	"github.com/ricoberger/kubetop/pkg/term/helpers"
@@ -135,6 +136,9 @@ func (p *PodDetailsWidget) Update() error {
 		}
 
 		// Render the first section of pod details: name, namespace, node, controlled by
+		// First we create our string for the controlled by field.
+		// Then we create our string for the events.
+		// We render a maximum amount of five events, sorted by the timestamp (timestamp is the time when the event was fired the last time).
 		var controlledBy string
 		for index, controller := range pod.ControlledBy {
 			if index == 0 {
@@ -144,12 +148,20 @@ func (p *PodDetailsWidget) Update() error {
 			}
 		}
 
+		sort.SliceStable(pod.Events, func(i, j int) bool {
+			return pod.Events[i].Timestamp > pod.Events[j].Timestamp
+		})
+
 		var events string
 		for index, event := range pod.Events {
+			if index == 5 {
+				break
+			}
+
 			if index == 0 {
-				events = events + event.Message
+				events = events + time.Unix(event.Timestamp, 0).Format("Mon, 02 Jan 2006 15:04:05 -0700") + ": " + event.Message
 			} else {
-				events = events + "\n               " + event.Message
+				events = events + "\n               " + time.Unix(event.Timestamp, 0).Format("Mon, 02 Jan 2006 15:04:05 -0700") + ": " + event.Message
 			}
 		}
 

--- a/pkg/term/widgets/poddetails.go
+++ b/pkg/term/widgets/poddetails.go
@@ -213,11 +213,11 @@ func (p *PodDetailsWidget) Update() error {
 			strings[i][1] = fmt.Sprintf("%d", container.Restarts)
 			strings[i][2] = container.Status
 			strings[i][3] = fmt.Sprintf("%dm", container.CPU)
-			strings[i][4] = fmt.Sprintf("%dm", container.CPUMin)
-			strings[i][5] = fmt.Sprintf("%dm", container.CPUMax)
+			strings[i][4] = helpers.RenderCPUMax(container.CPUMin, 1, 1)
+			strings[i][5] = helpers.RenderCPUMax(container.CPUMax, 1, 1)
 			strings[i][6] = helpers.FormatBytes(container.Memory)
-			strings[i][7] = helpers.FormatBytes(container.MemoryMin)
-			strings[i][8] = helpers.FormatBytes(container.MemoryMax)
+			strings[i][7] = helpers.RenderMemoryMax(container.MemoryMin, 1, 1)
+			strings[i][8] = helpers.RenderMemoryMax(container.MemoryMax, 1, 1)
 		}
 
 		p.containers.Rows = strings


### PR DESCRIPTION
- The table for containers display a dash instead of a zero for missing values for `CPUMin`, `CPUMax`, `MemoryMin` and `MemoryMax`
- The readme contains a better overview of the key mapping
- Add a `pods` command which also shows the pods view as first (same as running `kubetop` without any command)
- Add the timestamp to the events of a pod and show the events in descending order